### PR TITLE
Add admin equipment listing assertions

### DIFF
--- a/backend/src/test/java/oliveiradev/inventario/interfaces/controller/Equipamentos/EquipamentoControllerTest.java
+++ b/backend/src/test/java/oliveiradev/inventario/interfaces/controller/Equipamentos/EquipamentoControllerTest.java
@@ -159,7 +159,10 @@ class EquipamentoControllerTest {
         @WithMockUser(username = "admin@test.com", roles = {"USUARIO_ADMIN"})
         void listarTodosEquipamentos_ComoAdmin_DeveRetornarLista() throws Exception {
             when(equipamentoAppService.listarTodosEquipamentos()).thenReturn(List.of(equipamentoRespostaDTO));
-            mockMvc.perform(get("/api/equipamentos")).andExpect(status().isOk());
+            mockMvc.perform(get("/api/equipamentos"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(1)))
+                    .andExpect(jsonPath("$[0].id", is(equipamentoIdExistente)));
         }
 
 


### PR DESCRIPTION
## Summary
- extend equipment controller tests to check admin listing response body

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684987625e2883339c0a668b45d7e3d1