### PR TITLE
Fix typo in EquipamentoAppServiceImplTest

### DIFF
--- a/backend/src/test/java/oliveiradev/inventario/application/impl/equipamentos/EquipamentoAppServiceImplTest.java
+++ b/backend/src/test/java/oliveiradev/inventario/application/impl/equipamentos/EquipamentoAppServiceImplTest.java
@@ -169,7 +169,7 @@ class EquipamentoAppServiceImplTest {
         @DisplayName("Deve atualizar nome e descrição e adicionar logs")
         void atualizarEquipamento_ComNovosDados_DeveAtualizarEAdicionarLogs() {
             EquipamentoAtualizacaoDTO atualizacaoDTO = new EquipamentoAtualizacaoDTO("Nome Atualizado", "Descrição Atualizada");
-            // Usar spy para interagir com o objeto real Equipamento e verificar chamadas de métod
+            // Usar spy para interagir com o objeto real Equipamento e verificar chamadas de métodos
             Equipamento equipamentoExistenteSpy = spy(new Equipamento(equipamentoCriacaoDTO.nome(), equipamentoCriacaoDTO.numeroDeSerie(), equipamentoCriacaoDTO.descricaoDetalhada()));
             // Simular que o equipamento já tem um log de criação
             equipamentoExistenteSpy.adicionarLog(mockUserEmail, "Equipamento registrado no sistema por " + mockUserEmail + ".");


### PR DESCRIPTION
## Summary
- fix a comment typo in EquipamentoAppServiceImplTest

## Testing
- `grep -n "chamadas de m" -n backend/src/test/java/oliveiradev/inventario/application/impl/equipamentos/EquipamentoAppServiceImplTest.java`

------
https://chatgpt.com/codex/tasks/task_e_6849875de64c8333b5a26396075dc271